### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -323,7 +323,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.update-repository.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v6
         # env:
         #   GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 'Setup PDM for build commands'
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v4.1
 
       - name: 'Setup Python 3.10'
         uses: actions/setup-python@v5.2.0
@@ -157,7 +157,7 @@ jobs:
           rm dist/*.sig*
 
       - name: 'Setup PDM for build commands'
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@v3
 
       - name: 'Publish release to PyPI'
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
           ignore-from-file: [.gitignore],}"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.4
+    rev: v0.6.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit